### PR TITLE
Auto Correct Foreign Keys - V2 (Laravel 12)

### DIFF
--- a/src/Connections/PtOnlineSchemaChangeConnection.php
+++ b/src/Connections/PtOnlineSchemaChangeConnection.php
@@ -2,6 +2,9 @@
 
 namespace Daursu\ZeroDowntimeMigration\Connections;
 
+use Daursu\ZeroDowntimeMigration\Transformers\DatabaseTransformer;
+use Illuminate\Support\Collection;
+
 class PtOnlineSchemaChangeConnection extends BaseConnection
 {
     /**
@@ -69,23 +72,48 @@ class PtOnlineSchemaChangeConnection extends BaseConnection
     protected function runQueries($queries)
     {
         $table = $this->extractTableFromQuery($queries[0]);
+        $cleanQueries = $this->applyTransformers($table, $queries);
 
-        $cleanQueries = [];
-        foreach($queries as $query) {
-            $cleanQueries[] = $this->cleanQuery($query);
+        $runCommand = $this->makeCommand($table, $cleanQueries, $this->isPretending());
+        return $this->runProcess($runCommand);
+    }
+
+    /**
+     * @return array<string>
+     */
+    protected function makeCommand(string $table, Collection $queries, bool $dryRun = false): array
+    {
+        // array_filter to strip empty lines from `getAdditionalParameters`
+        return array_filter(array_merge(
+            ['pt-online-schema-change', $dryRun ? '--dry-run' : '--execute'],
+            $this->getAdditionalParameters(),
+            ['--alter', $queries->join(', '), $this->getAuthString($table)]
+        ));
+    }
+
+    /**
+     * @return Collection<string>
+     */
+    protected function applyTransformers(string $tableName, array $queries): Collection
+    {
+        $cleanQueries = collect($queries)->map(fn (string $query) => $this->cleanQuery($query));
+        $dryRunCommand = $this->makeCommand($tableName, $cleanQueries, true);
+
+        foreach ($this->getDatabaseTransformers() as $transformer) {
+            $transformer->transformState($tableName, $cleanQueries, $dryRunCommand);
+            $cleanQueries = $transformer->transformQueries($tableName, $cleanQueries, $dryRunCommand);
         }
 
-        return $this->runProcess(array_merge(
-            [
-                'pt-online-schema-change',
-                $this->isPretending() ? '--dry-run' : '--execute',
-            ],
-            $this->getAdditionalParameters(),
-            [
-                '--alter',
-                implode(', ', $cleanQueries),
-                $this->getAuthString($table),
-            ]
-        ));
+        return $cleanQueries;
+    }
+
+    /**
+     * @return Collection<DatabaseTransformer>
+     */
+    protected function getDatabaseTransformers(): Collection
+    {
+        $trasnformerClasses = config('zero-downtime-migrations.transformers');
+
+        return collect($trasnformerClasses)->map(fn (string $className) => new $className());
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -19,7 +19,14 @@ class ServiceProvider extends IlluminateServiceProvider
      */
     public function boot()
     {
-        //
+        $this->mergeConfigFrom(
+            __DIR__ . '/config/zero-downtime-migrations.php',
+            'zero-downtime-migrations'
+        );
+
+        $this->publishes([
+            __DIR__ . '/config/zero-downtime-migrations.php' => config_path('zero-downtime-migrations.php'),
+        ]);
     }
 
     /**

--- a/src/Transformers/DatabaseTransformer.php
+++ b/src/Transformers/DatabaseTransformer.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Daursu\ZeroDowntimeMigration\Transformers;
+
+use Illuminate\Support\Collection;
+
+/**
+ * Transformers are classes executed just before running zero-downtime migrations
+ * to help account for common "gotchas" in different zero-downtime packages.
+ */
+abstract class DatabaseTransformer
+{
+    /**
+     * Execute queries altering the state of the database here. For example, dropping
+     * leftover triggers.
+     *
+     * @param string $tableName
+     * @param Collection<string> $alterQueries
+     * @param array $dryRunCommand
+     * @return void
+     */
+    public function transformState(string $tableName, Collection $alterQueries, array $dryRunCommand)
+    {
+        // No-op
+    }
+
+    /**
+     * Returns modifies versions of the queries that were originally going to be executed.
+     * For example, for updating column names and such to reflect their new names in the
+     * cloned table.
+     *
+     * @param string $tableName
+     * @param Collection<string> $alterQueries
+     * @param array $dryRunCommand
+     * @return Collection<string>
+     */
+    public function transformQueries(string $tableName, Collection $alterQueries, array $dryRunCommand): Collection
+    {
+        return $alterQueries;
+    }
+}

--- a/src/Transformers/PtOnlineSchemaChange/DropOldTables.php
+++ b/src/Transformers/PtOnlineSchemaChange/DropOldTables.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Daursu\ZeroDowntimeMigration\Transformers\PtOnlineSchemaChange;
+
+use Daursu\ZeroDowntimeMigration\Transformers\DatabaseTransformer;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+class DropOldTables extends DatabaseTransformer
+{
+    public function transformState(string $tableName, Collection $alterQueries, array $dryRunCommand)
+    {
+        static::dropOldTables($tableName);
+    }
+
+    /**
+     * Sometimes tools like `pt-only-schema-change` leave behind cloned table
+     * (e.g. `_books_new`) that will cause subsequent operations to blow up.
+     * So, we remove them.
+     */
+    public static function dropOldTables(string $tableName)
+    {
+        Log::info('Dropping old zero-downtime tables...');
+
+        static::getZeroDowntimeTables($tableName)->each(function ($table) {
+            Schema::withoutForeignKeyConstraints(function () use ($table) {
+                return Schema::dropIfExists($table);
+            });
+            Log::info("Dropped zero-downtime table: {$table}");
+        });
+    }
+
+    /**
+     * Get tables created by pt-online-schema-change for zero downtime migrations.
+     * These tables are identified by having a name ending with the given table name, prefixed with an underscore.
+     *
+     * @param string $tableName The base table name to check against.
+     * @return Collection<string> An array of tables to be dropped.
+     */
+    private static function getZeroDowntimeTables(string $tableName): Collection
+    {
+        $tablePattern1 = '_' . $tableName . '_new';
+        $tablePattern2 = '_' . $tableName . '_old';
+
+        return collect(DB::select('SHOW TABLES'))
+            ->map(fn ($table) => array_values((array)$table)[0])
+            ->filter(fn ($tableName) => Str::endsWith($tableName, $tablePattern1) ||
+                Str::endsWith($tableName, $tablePattern2));
+    }
+}

--- a/src/Transformers/PtOnlineSchemaChange/DropOldTriggers.php
+++ b/src/Transformers/PtOnlineSchemaChange/DropOldTriggers.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Daursu\ZeroDowntimeMigration\Transformers\PtOnlineSchemaChange;
+
+use Daursu\ZeroDowntimeMigration\Transformers\DatabaseTransformer;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class DropOldTriggers extends DatabaseTransformer
+{
+
+    public function transformState(string $tableName, Collection $alterQueries, array $dryRunCommand)
+    {
+        static::dropOldTriggers($tableName);
+    }
+
+    /**
+     * During the cloning phase, tools like `pt-only-schema-change` sometimes leave behind
+     * triggers like `pt_osc_*` if they failed, which then blows up with obscure `--preserve-triggers`
+     * errors later on. So, we remove them.
+     */
+    public static function dropOldTriggers($tableName)
+    {
+        Log::info('Dropping old zero-downtime triggers...');
+
+        static::getZeroDowntimeTriggers($tableName)->each(function ($trigger) {
+            DB::unprepared("DROP TRIGGER IF EXISTS {$trigger}");
+            Log::info("Dropped zero-downtime trigger: {$trigger}");
+        });
+    }
+
+    /**
+     * Get triggers associated with zero downtime migration process, typically starting with 'pt_osc_'.
+     *
+     * @param string $tableName The base table name to check triggers against.
+     * @return Collection<string> An array of triggers to be dropped.
+     */
+    private static function getZeroDowntimeTriggers(string $tableName): Collection
+    {
+        return collect(DB::select("SHOW TRIGGERS WHERE `Trigger` LIKE 'pt_osc_%' AND `Table` = ?", [$tableName]))
+            ->pluck('Trigger');
+    }
+}

--- a/src/Transformers/PtOnlineSchemaChange/UpdateForeignKeys.php
+++ b/src/Transformers/PtOnlineSchemaChange/UpdateForeignKeys.php
@@ -30,6 +30,7 @@ class UpdateForeignKeys extends DatabaseTransformer
     private function dryRun(array $command): string
     {
         $process = new Process($command);
+        $process->setTimeout(null);
         $process->run();
         $process->stop();
 

--- a/src/Transformers/PtOnlineSchemaChange/UpdateForeignKeys.php
+++ b/src/Transformers/PtOnlineSchemaChange/UpdateForeignKeys.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Daursu\ZeroDowntimeMigration\Transformers\PtOnlineSchemaChange;
+
+use Daursu\ZeroDowntimeMigration\Transformers\DatabaseTransformer;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\Process\Process;
+
+/**
+ * @see https://docs.percona.com/percona-toolkit/pt-online-schema-change.html#options
+ *
+ *   DROP FOREIGN KEY constraint_name requires specifying _constraint_name rather than
+ *   the real constraint_name. Due to a limitation in MySQL, pt-online-schema-change adds
+ *   a leading underscore to foreign key constraint names when creating the new table.
+ *
+ * To work around this, this class leverages a dry run to identify the new keys and then
+ * transforms the queries aobut to be executed to use the new keys.
+ */
+class UpdateForeignKeys extends DatabaseTransformer
+{
+    public function transformQueries(string $tableName, Collection $alterQueries, array $dryRunCommand): Collection
+    {
+        Log::info('Updating foreign keys...');
+
+        $dryRunOutput = $this->dryRun($dryRunCommand);
+        return $this->getTransformedQueries($alterQueries, $dryRunOutput);
+    }
+
+    private function dryRun(array $command): string
+    {
+        $process = new Process($command);
+        $process->run();
+        $process->stop();
+
+        return $process->getOutput();
+    }
+
+    /**
+     * @param Collection<string> $queries
+     * @return Collection<string>
+     */
+    private function getTransformedQueries(Collection $queries, string $dryRunOutput): Collection
+    {
+        $baseNameToNewName = $this->getNewForeignKeyNameMap($dryRunOutput);
+
+        return $queries->map(function ($query) use ($baseNameToNewName) {
+            if ($key = str($query)->match("/drop foreign key `(.*?)`/i")->toString()) {
+                $baseName = ltrim($key, '_');
+                $newName = $baseNameToNewName->get($baseName);
+
+                if ($newName && ($newName !== $key)) {
+                    Log::info("Re-mapping foreign key name from $key to $newName.");
+                    return str($query)->replace("`$key`", "`$newName`")->value();
+                }
+            }
+
+            return $query;
+        });
+    }
+
+    /**
+     * @return Collection<string>
+     */
+    private function getNewForeignKeyNameMap(string $dryRunOutput): Collection
+    {
+        return str($dryRunOutput)
+            ->matchAll("/constraint `(.*?)`/i")
+            ->keyBy(fn ($name) => ltrim($name, '_'));
+    }
+}

--- a/src/config/zero-downtime-migrations.php
+++ b/src/config/zero-downtime-migrations.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'transformers' => [
+        \Daursu\ZeroDowntimeMigration\Transformers\PtOnlineSchemaChange\DropOldTables::class,
+        \Daursu\ZeroDowntimeMigration\Transformers\PtOnlineSchemaChange\DropOldTriggers::class,
+        \Daursu\ZeroDowntimeMigration\Transformers\PtOnlineSchemaChange\UpdateForeignKeys::class
+    ],
+];

--- a/tests/Unit/PtOnlineSchemaChangeConnectionTest.php
+++ b/tests/Unit/PtOnlineSchemaChangeConnectionTest.php
@@ -4,7 +4,7 @@ namespace Unit;
 
 use Daursu\ZeroDowntimeMigration\Connections\PtOnlineSchemaChangeConnection;
 use Illuminate\Support\Str;
-use PHPUnit\Framework\TestCase;
+use Orchestra\Testbench\TestCase;
 use Symfony\Component\Process\Exception\RuntimeException;
 use Symfony\Component\Process\Process;
 


### PR DESCRIPTION
Here's [the related issue](https://github.com/Daursu/laravel-zero-downtime-migration/issues/43#issue-2360875628) for why this hasn't been merged upstream.

Making a second branch because:
1. App API is pointing directly at the GitHub-hosted commits, which means we shouldn't modify history on the active branch.
2. To get a clean diff of what our changes are over master.

---

This was a small follow-up to https://github.com/packbackbooks/laravel-zero-downtime-migration/pull/1 to avoid changing commit hashes, and was rebased onto the upstream's `master` branch for Laravel 12 support. Same as before, closing since it doesn't look like this'll get merged. Fortunately we don't need to touch this package very often.